### PR TITLE
Update Wapoo.cs

### DIFF
--- a/Wupoo/Wapoo.cs
+++ b/Wupoo/Wapoo.cs
@@ -123,7 +123,7 @@ namespace Wupoo
                         message = await client.GetAsync(_url);
                         break;
                     case HttpMethods.Post:
-                        if (postContent == null) throw new PostBodyNotGivenException();
+                        if (postContent == null) this.WithJsonBody(new object());
                         message = await client.PostAsync(_url, postContent);
                         break;
                     default:


### PR DESCRIPTION
Post体为null时，也可以进行Post而不是为空抛异常
修复为为null时，初始化Post体为new object();